### PR TITLE
#94 - Render function when changing coordinates for Marker comp

### DIFF
--- a/src/components/Marker/index.js
+++ b/src/components/Marker/index.js
@@ -54,6 +54,7 @@ class Marker extends PureComponent<Props> {
 
     if (positionChanged) {
       this._marker.setLngLat([this.props.longitude, this.props.latitude]);
+      render(this.props.element, this._container);
     }
   }
 


### PR DESCRIPTION
By calling the render function in the componentDidUpdate hook, we are re-rendering the Marker components props which include the element property that are pointing to the passed ClusterElement