### PR TITLE
feat(Controls): Add getControl()

### DIFF
--- a/src/components/AttributionControl/index.js
+++ b/src/components/AttributionControl/index.js
@@ -35,6 +35,10 @@ class AttributionControl extends PureComponent<Props> {
     position: 'bottom-right'
   };
 
+  getControl() {
+    return this._control;
+  }
+
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { compact, customAttribution, position } = this.props;

--- a/src/components/AttributionControl/index.js
+++ b/src/components/AttributionControl/index.js
@@ -35,10 +35,6 @@ class AttributionControl extends PureComponent<Props> {
     position: 'bottom-right'
   };
 
-  getControl() {
-    return this._control;
-  }
-
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { compact, customAttribution, position } = this.props;
@@ -58,6 +54,10 @@ class AttributionControl extends PureComponent<Props> {
     }
 
     this._map.removeControl(this._control);
+  }
+
+  getControl() {
+    return this._control;
   }
 
   render() {

--- a/src/components/FullscreenControl/index.js
+++ b/src/components/FullscreenControl/index.js
@@ -32,6 +32,10 @@ class FullscreenControl extends PureComponent<Props> {
     position: 'top-right'
   };
 
+  getControl() {
+    return this._control;
+  }
+
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { container, position } = this.props;

--- a/src/components/FullscreenControl/index.js
+++ b/src/components/FullscreenControl/index.js
@@ -32,10 +32,6 @@ class FullscreenControl extends PureComponent<Props> {
     position: 'top-right'
   };
 
-  getControl() {
-    return this._control;
-  }
-
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { container, position } = this.props;
@@ -54,6 +50,10 @@ class FullscreenControl extends PureComponent<Props> {
     }
 
     this._map.removeControl(this._control);
+  }
+
+  getControl() {
+    return this._control;
   }
 
   render() {

--- a/src/components/GeolocateControl/index.js
+++ b/src/components/GeolocateControl/index.js
@@ -69,10 +69,6 @@ class GeolocateControl extends PureComponent<Props> {
     showUserLocation: true
   };
 
-  getControl() {
-    return this._control;
-  }
-
   componentDidMount() {
     const map: MapboxMap = this._map;
     const {
@@ -120,6 +116,10 @@ class GeolocateControl extends PureComponent<Props> {
     }
 
     this._map.removeControl(this._control);
+  }
+
+  getControl() {
+    return this._control;
   }
 
   render() {

--- a/src/components/GeolocateControl/index.js
+++ b/src/components/GeolocateControl/index.js
@@ -69,6 +69,10 @@ class GeolocateControl extends PureComponent<Props> {
     showUserLocation: true
   };
 
+  getControl() {
+    return this._control;
+  }
+
   componentDidMount() {
     const map: MapboxMap = this._map;
     const {

--- a/src/components/NavigationControl/index.js
+++ b/src/components/NavigationControl/index.js
@@ -30,6 +30,10 @@ class NavigationControl extends PureComponent<Props> {
     position: 'top-right'
   };
 
+  getControl() {
+    return this._control;
+  }
+
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { showCompass, showZoom, position } = this.props;

--- a/src/components/NavigationControl/index.js
+++ b/src/components/NavigationControl/index.js
@@ -30,10 +30,6 @@ class NavigationControl extends PureComponent<Props> {
     position: 'top-right'
   };
 
-  getControl() {
-    return this._control;
-  }
-
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { showCompass, showZoom, position } = this.props;
@@ -53,6 +49,10 @@ class NavigationControl extends PureComponent<Props> {
     }
 
     this._map.removeControl(this._control);
+  }
+
+  getControl() {
+    return this._control;
   }
 
   render() {

--- a/src/components/ScaleControl/index.js
+++ b/src/components/ScaleControl/index.js
@@ -32,10 +32,6 @@ class ScaleControl extends PureComponent<Props> {
     unit: 'metric'
   };
 
-  getControl() {
-    return this._control;
-  }
-
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { maxWidth, unit, position } = this.props;
@@ -55,6 +51,10 @@ class ScaleControl extends PureComponent<Props> {
     }
 
     this._map.removeControl(this._control);
+  }
+
+  getControl() {
+    return this._control;
   }
 
   render() {

--- a/src/components/ScaleControl/index.js
+++ b/src/components/ScaleControl/index.js
@@ -32,6 +32,10 @@ class ScaleControl extends PureComponent<Props> {
     unit: 'metric'
   };
 
+  getControl() {
+    return this._control;
+  }
+
   componentDidMount() {
     const map: MapboxMap = this._map;
     const { maxWidth, unit, position } = this.props;


### PR DESCRIPTION
The usecase for that is to be able to use the methods exposed by mapbox's controls, like `trigger()` of the GeolocateControl

Example
```js
<MapGL onLoad={e => this.geolocateControlRef.current.getControl().trigger()}>
 <GeolocateControl ref={this.geolocateControlRef} />
</MapGL>
```