### PR TITLE
feat(MapGL): add showTileBoundaries prop

### DIFF
--- a/src/components/MapGL/index.js
+++ b/src/components/MapGL/index.js
@@ -220,7 +220,13 @@ type Props = EventProps & {
   onLoad?: Function,
 
   /** Map cursor style as CSS value */
-  cursorStyle?: string
+  cursorStyle?: string,
+
+  /**
+   * Sets a Boolean indicating whether the map will render an outline around
+   * each tile and the tile ID. These tile boundaries are useful for debugging.
+   * */
+  showTileBoundaries?: boolean
 };
 
 type State = {
@@ -354,6 +360,10 @@ class MapGL extends PureComponent<Props, State> {
     if (this.props.cursorStyle) {
       map.getCanvas().style.cursor = this.props.cursorStyle;
     }
+
+    if (this.props.showTileBoundaries) {
+      this._map.showTileBoundaries = this.props.showTileBoundaries;
+    }
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -362,6 +372,10 @@ class MapGL extends PureComponent<Props, State> {
 
     if (!prevProps.cursorStyle !== this.props.cursorStyle) {
       this._map.getCanvas().style.cursor = this.props.cursorStyle;
+    }
+
+    if (prevProps.showTileBoundaries !== this.props.showTileBoundaries) {
+      this._map.showTileBoundaries = this.props.showTileBoundaries;
     }
   }
 

--- a/src/components/MapGL/index.js
+++ b/src/components/MapGL/index.js
@@ -375,7 +375,7 @@ class MapGL extends PureComponent<Props, State> {
     }
 
     if (prevProps.showTileBoundaries !== this.props.showTileBoundaries) {
-      this._map.showTileBoundaries = this.props.showTileBoundaries;
+      this._map.showTileBoundaries = !!this.props.showTileBoundaries;
     }
   }
 

--- a/src/components/MapGL/index.test.js
+++ b/src/components/MapGL/index.test.js
@@ -281,3 +281,13 @@ test('renders without mapbox-gl', () => {
   const map = wrapper.instance().getMap();
   expect(map).toBeFalsy();
 });
+
+test('renders with tileBoundaries', () => {
+  const wrapper = mount(
+    <MapGL latitude={0} longitude={0} zoom={0} showTileBoundaries />
+  );
+
+  expect(wrapper.exists()).toBe(true);
+  const map = wrapper.instance().getMap();
+  expect(map).toBeTruthy();
+});

--- a/src/components/MapGL/index.test.js
+++ b/src/components/MapGL/index.test.js
@@ -287,7 +287,10 @@ test('renders with tileBoundaries', () => {
     <MapGL latitude={0} longitude={0} zoom={0} showTileBoundaries />
   );
 
-  expect(wrapper.exists()).toBe(true);
   const map = wrapper.instance().getMap();
-  expect(map).toBeTruthy();
+
+  expect(map.showTileBoundaries).toBe(true);
+
+  wrapper.setProps({ showTileBoundaries: false });
+  expect(map.showTileBoundaries).toBe(false);
 });


### PR DESCRIPTION
This pr add [showtileboundaries](https://docs.mapbox.com/mapbox-gl-js/api/#map#showtileboundaries) functionality.