### PR TITLE
Update example to use viewportChangeOptions

### DIFF
--- a/src/components/MapGL/README.md
+++ b/src/components/MapGL/README.md
@@ -136,6 +136,10 @@ initialState = {
   }
 };
 
+changeOptions = {
+  duration: 1000
+}
+
 const onChange = (event) => {
   setState({ viewportChangeMethod: event.target.value });
 };
@@ -166,6 +170,7 @@ const onClick = (event) => {
     onClick={onClick}
     onViewportChange={(viewport) => setState({ viewport })}
     viewportChangeMethod={state.viewportChangeMethod}
+    viewportChangeOptions={changeOptions}
     {...state.viewport}
   />
 </React.Fragment>;


### PR DESCRIPTION
Nothing big, but as a beginner, took a bit of time for me to look for how to actually change the flyTo options. It might be helpful to include in the documentation an example of how to use viewportChangeOptions as a prop, especially for more MapBox beginners.

Let me know if this makes sense! Thanks so much, am a big fan of your work and a constant user of this repo :D