### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react",
     "urbica"
   ],
+  "types": "src/index.d.ts",
   "main": "dist/react-map-gl.cjs.js",
   "module": "dist/react-map-gl.esm.js",
   "files": [

--- a/src/components/AttributionControl/index.d.ts
+++ b/src/components/AttributionControl/index.d.ts
@@ -1,0 +1,22 @@
+import { PureComponent, ReactNode } from "react";
+import type { AttributionControl as MapboxAttributionControl } from "mapbox-gl";
+
+type Props = {
+  /**
+   * If `true` force a compact attribution that shows the full
+   * attribution on mouse hover, or if  false force the full attribution
+   * control. The default is a responsive attribution that collapses when
+   * the map is less than 640 pixels wide.
+   */
+  compact: boolean;
+
+  /* String or strings to show in addition to any other attributions. */
+  customAttribution: string | Array<string>;
+
+  /* A string representing the position of the control on the map. */
+  position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+};
+
+export default class AttributionControl extends PureComponent<Props> {
+  getControl(): MapboxAttributionControl;
+}

--- a/src/components/CustomLayer/index.d.ts
+++ b/src/components/CustomLayer/index.d.ts
@@ -1,0 +1,19 @@
+import { PureComponent, createElement, ReactNode } from "react";
+import type MapboxMap from "mapbox-gl/src/ui/map";
+import type { CustomLayerInterface } from "mapbox-gl/src/style/style_layer/custom_style_layer";
+import MapContext from "../MapContext";
+
+type Props = {
+  /** The id of an existing layer to insert the new layer before. */
+  before?: string;
+
+  /** Mapbox GL Custom Layer instance */
+  layer: CustomLayerInterface;
+};
+/**
+ * Custom layers allow a user to render directly into the map's GL context
+ * using the map's camera.
+ */
+
+export default class CustomLayer extends PureComponent<Props> {
+}

--- a/src/components/FeatureState/index.d.ts
+++ b/src/components/FeatureState/index.d.ts
@@ -1,0 +1,17 @@
+import { PureComponent } from "react";
+
+type Props = {
+  /** Unique id of the feature. */
+  id: string | number;
+
+  /** The Id of the vector source or GeoJSON source for the feature. */
+  source: string;
+
+  /** For vector tile sources, the sourceLayer is required. */
+  sourceLayer: string;
+
+  /** A set of key-value pairs. The values should be valid JSON types. */
+  state: Object;
+};
+
+export default class FeatureState extends PureComponent<Props> {}

--- a/src/components/Filter/index.d.ts
+++ b/src/components/Filter/index.d.ts
@@ -1,0 +1,24 @@
+import type { FilterSpecification } from "mapbox-gl/src/style-spec/types";
+import { PureComponent } from "react";
+
+type Props = {
+  /** Mapbox GL Layer id */
+  layerId: string;
+  /**
+   * The filter, conforming to the Mapbox Style Specification's
+   * filter definition. (see https://docs.mapbox.com/mapbox-gl-js/style-spec/#other-filter)
+   * If null or undefined is provided, the function removes any existing filter
+   * from the layer.
+   * */
+  filter: FilterSpecification;
+
+  /**
+   * Whether to check if the filter conforms to the Mapbox GL
+   * Style Specification. Disabling validation is a performance optimization
+   * that should only be used if you have previously validated the values you
+   * will be passing to this function.
+   * */
+  validate?: boolean;
+};
+
+export default class Filter extends PureComponent<Props> {}

--- a/src/components/FullscreenControl/index.d.ts
+++ b/src/components/FullscreenControl/index.d.ts
@@ -1,0 +1,18 @@
+import { PureComponent } from "react";
+import type { FullscreenControl as MapboxFullscreenControl } from "mapbox-gl";
+
+type Props = {
+  /**
+   * container is the compatible DOM element which should be
+   * made full screen. By default, the map container element
+   * will be made full screen.
+   */
+  container: string;
+
+  /* A string representing the position of the control on the map. */
+  position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+};
+
+export default class FullscreenControl extends PureComponent<Props> {
+  getControl(): MapboxFullscreenControl;
+}

--- a/src/components/GeolocateControl/index.d.ts
+++ b/src/components/GeolocateControl/index.d.ts
@@ -1,0 +1,52 @@
+import { PureComponent } from "react";
+import type { GeolocateControl as MapboxGeolocateControl } from "mapbox-gl";
+
+type Props = {
+  /* A Geolocation API PositionOptions object. */
+  positionOptions: PositionOptions;
+
+  /**
+   * A `fitBounds` options object to use when the map is
+   * panned and zoomed to the user's location.
+   */
+  fitBoundsOptions: Object;
+
+  /**
+   * If `true` the Geolocate Control becomes a toggle button and when active
+   * the map will receive updates to the user's location as it changes.
+   */
+  trackUserLocation: boolean;
+
+  /**
+   * By default a dot will be shown on the map at the user's location.
+   * Set to `false` to disable.
+   */
+  showUserLocation: boolean;
+
+  /* A string representing the position of the control on the map. */
+  position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+  /**
+   * Fired when the Geolocate Control changes to the background state.
+   */
+  onTrackUserLocationEnd?: Function;
+
+  /**
+   * Fired when the Geolocate Control changes to the active lock state,
+   */
+  onTrackUserLocationStart?: Function;
+
+  /**
+   * Fired on each Geolocation API position update which returned as an error.
+   */
+  onError?: Function;
+
+  /**
+   * Fired on each Geolocation API position update which returned as success.
+   */
+  onGeolocate?: Function;
+};
+
+export default class GeolocateControl extends PureComponent<Props> {
+  getControl(): MapboxGeolocateControl;
+}

--- a/src/components/Image/index.d.ts
+++ b/src/components/Image/index.d.ts
@@ -1,0 +1,30 @@
+import type { StyleImageInterface } from "mapbox-gl/src/style/style_image";
+import { PureComponent } from "react";
+
+type MapboxImage =
+  | HTMLImageElement
+  | ImageData
+  | { width: number; height: number; data: Uint8Array | Uint8ClampedArray }
+  | StyleImageInterface;
+
+type Props = {
+  /** The ID of the image. */
+  id: string;
+
+  /**
+   * The image as an `HTMLImageElement`, `ImageData`, object with `width`,
+   * `height`, and `data` properties with the same format as `ImageData`
+   * or image url string
+   * */
+  image: MapboxImage | string;
+
+  /** The ratio of pixels in the image to physical pixels on the screen */
+  pixelRatio?: number;
+
+  /** Whether the image should be interpreted as an SDF image */
+  sdf?: boolean;
+};
+
+export default class Image extends PureComponent<Props> {
+  constructor(props: Props);
+}

--- a/src/components/LanguageControl/index.d.ts
+++ b/src/components/LanguageControl/index.d.ts
@@ -1,0 +1,32 @@
+import { PureComponent } from "react";
+import type MapboxLanguageControl from "@mapbox/mapbox-gl-language/index";
+
+type Props = {
+  /** List of supported languages */
+  supportedLanguages?: string[];
+
+  /** Custom style transformation to apply */
+  languageTransform?: Function;
+
+  /**
+   * RegExp to match if a text-field is a language field
+   * (optional, default /^\{name/)
+   */
+  languageField?: RegExp;
+
+  /** Given a language choose the field in the vector tiles */
+  getLanguageField?: Function;
+
+  /** Name of the source that contains the different languages. */
+  languageSource?: string;
+
+  /** Name of the default language to initialize style after loading. */
+  defaultLanguage?: string;
+
+  /** Name of the language to set */
+  language?: string;
+};
+
+export default class LanguageControl extends PureComponent<Props> {
+  getControl(): MapboxLanguageControl;
+}

--- a/src/components/Layer/index.d.ts
+++ b/src/components/Layer/index.d.ts
@@ -1,0 +1,65 @@
+import { MapMouseEvent } from "mapbox-gl";
+import type GeoJSONFeature from "mapbox-gl/src/util/vectortile_to_geojson";
+import { LayerSpecification } from "mapbox-gl/src/style-spec/types";
+import { PureComponent } from "react";
+
+type InteractionEvent = MapMouseEvent & { features?: GeoJSONFeature[] };
+
+type Props = LayerSpecification & {
+  /** Mapbox GL Layer id */
+  id: string;
+
+  /** The id of an existing layer to insert the new layer before. */
+  before?: string;
+
+  /**
+   * Called when the layer is clicked.
+   * @callback
+   * @param {Object} event - The mouse event.
+   * @param {[Number, Number]} event.lngLat - The coordinates of the pointer
+   * @param {Array} event.features - The features under the pointer,
+   * using Mapbox's queryRenderedFeatures API:
+   * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+   */
+  onClick?: (event: InteractionEvent) => any;
+
+  /**
+   * Called when the layer is hovered over.
+   * @callback
+   * @param {Object} event - The mouse event.
+   * @param {[Number, Number]} event.lngLat - The coordinates of the pointer
+   * @param {Array} event.features - The features under the pointer,
+   * using Mapbox's queryRenderedFeatures API:
+   * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+   */
+  onHover?: (event: InteractionEvent) => any;
+
+  /**
+   * Called when the layer feature is entered.
+   * @callback
+   * @param {Object} event - The mouse event.
+   * @param {[Number, Number]} event.lngLat - The coordinates of the pointer
+   * @param {Array} event.features - The features under the pointer,
+   * using Mapbox's queryRenderedFeatures API:
+   * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+   */
+  onEnter?: (event: InteractionEvent) => any;
+
+  /**
+   * Called when the layer feature is leaved.
+   * @callback
+   * @param {Object} event - The mouse event.
+   * @param {[Number, Number]} event.lngLat - The coordinates of the pointer
+   * @param {Array} event.features - The features under the pointer,
+   * using Mapbox's queryRenderedFeatures API:
+   * https://www.mapbox.com/mapbox-gl-js/api/#Map#queryRenderedFeatures
+   */
+  onLeave?: (event: InteractionEvent) => any;
+
+  /**
+   * Radius to detect features around a clicked/hovered point
+   */
+  radius: number;
+};
+
+export default class Layer extends PureComponent<Props> {}

--- a/src/components/MapContext/index.d.ts
+++ b/src/components/MapContext/index.d.ts
@@ -1,0 +1,6 @@
+import { Context } from "react";
+import { Map } from "mapbox-gl";
+
+declare const MapContext: Context<Map | null>;
+
+export default MapContext;

--- a/src/components/MapGL/eventProps.d.ts
+++ b/src/components/MapGL/eventProps.d.ts
@@ -1,0 +1,133 @@
+export type EventProps = {
+  /** The resize event handler */
+  onResize?: Function;
+
+  /** The remove event handler */
+  onRemove?: Function;
+
+  /** The mousedown event handler */
+  onMousedown?: Function;
+
+  /** The mouseup event handler */
+  onMouseup?: Function;
+
+  /** The mouseover event handler */
+  onMouseover?: Function;
+
+  /** The mousemove event handler */
+  onMousemove?: Function;
+
+  /** The click event handler */
+  onClick?: Function;
+
+  /** The dblclick event handler */
+  onDblclick?: Function;
+
+  /** The mouseenter event handler */
+  onMouseenter?: Function;
+
+  /** The mouseleave event handler */
+  onMouseleave?: Function;
+
+  /** The mouseout event handler */
+  onMouseout?: Function;
+
+  /** The contextmenu event handler */
+  onContextmenu?: Function;
+
+  /** The touchstart event handler */
+  onTouchstart?: Function;
+
+  /** The touchend event handler */
+  onTouchend?: Function;
+
+  /** The touchmove event handler */
+  onTouchmove?: Function;
+
+  /** The touchcancel event handler */
+  onTouchcancel?: Function;
+
+  /** The movestart event handler */
+  onMovestart?: Function;
+
+  /** The move event handler */
+  onMove?: Function;
+
+  /** The moveend event handler */
+  onMoveend?: Function;
+
+  /** The dragstart event handler */
+  onDragstart?: Function;
+
+  /** The drag event handler */
+  onDrag?: Function;
+
+  /** The dragend event handler */
+  onDragend?: Function;
+
+  /** The zoomstart event handler */
+  onZoomstart?: Function;
+
+  /** The zoom event handler */
+  onZoom?: Function;
+
+  /** The zoomend event handler */
+  onZoomend?: Function;
+
+  /** The rotatestart event handler */
+  onRotatestart?: Function;
+
+  /** The rotate event handler */
+  onRotate?: Function;
+
+  /** The rotateend event handler */
+  onRotateend?: Function;
+
+  /** The pitchstart event handler */
+  onPitchstart?: Function;
+
+  /** The pitch event handler */
+  onPitch?: Function;
+
+  /** The pitchend event handler */
+  onPitchend?: Function;
+
+  /** The boxzoomstart event handler */
+  onBoxzoomstart?: Function;
+
+  /** The boxzoomend event handler */
+  onBoxzoomend?: Function;
+
+  /** The boxzoomcancel event handler */
+  onBoxzoomcancel?: Function;
+
+  /** The webglcontextlost event handler */
+  onWebglcontextlost?: Function;
+
+  /** The webglcontextrestored event handler */
+  onWebglcontextrestored?: Function;
+
+  /** The load event handler */
+  onLoad?: Function;
+
+  /** The error event handler */
+  onError?: Function;
+
+  /** The data event handler */
+  onData?: Function;
+
+  /** The styledata event handler */
+  onStyledata?: Function;
+
+  /** The sourcedata event handler */
+  onSourcedata?: Function;
+
+  /** The dataloading event handler */
+  onDataloading?: Function;
+
+  /** The styledataloading event handler */
+  onStyledataloading?: Function;
+
+  /** The sourcedataloading event handler */
+  onSourcedataloading?: Function;
+};

--- a/src/components/MapGL/index.d.ts
+++ b/src/components/MapGL/index.d.ts
@@ -1,0 +1,272 @@
+import { StyleSpecification } from "mapbox-gl/src/style-spec/types";
+import type {
+  Map,
+  MapMouseEvent,
+  MapTouchEvent,
+  LngLatBoundsLike,
+  AnimationOptions,
+} from "mapbox-gl";
+import type { PureComponent, ReactNode } from "react";
+import { EventProps } from "./eventProps";
+
+export type Viewport = {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+  pitch?: number;
+  bearing?: number;
+};
+
+export const jumpTo = "jumpTo";
+export const easeTo = "easeTo";
+export const flyTo = "flyTo";
+
+export type ViewportChangeMethod = "jumpTo" | "easeTo" | "flyTo";
+export type ViewportChangeEvent = MapMouseEvent | MapTouchEvent;
+
+type Props = EventProps & {
+  /** container className */
+  className?: string;
+
+  /** container style */
+  style?: {
+    [CSSProperty: string]: any;
+  };
+
+  /**
+   * The Mapbox style. A string url or a Mapbox GL style object.
+   */
+  mapStyle: string | StyleSpecification;
+
+  /** MapGL children as Sources, Layers, Controls, and custom Components */
+  children?: ReactNode;
+
+  /**
+   * Mapbox API access token for mapbox-gl-js.
+   * Required when using Mapbox vector tiles/styles.
+   */
+  accessToken?: string;
+
+  /** The longitude of the center of the map. */
+  longitude: number;
+
+  /** The latitude of the center of the map. */
+  latitude: number;
+
+  /** The tile zoom level of the map. */
+  zoom: number;
+
+  /** Specify the bearing of the viewport */
+  bearing?: number;
+
+  /** Specify the pitch of the viewport */
+  pitch?: number;
+
+  /** The minimum zoom level of the map (0-22). */
+  minZoom?: number;
+
+  /** The maximum zoom level of the map (0-22). */
+  maxZoom?: number;
+
+  /**
+   * If `true`, the map's position (zoom, center latitude,
+   * center longitude, bearing, and pitch) will be synced
+   * with the hash fragment of the page's URL. For example,
+   * http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60.
+   */
+  hash?: boolean;
+
+  /**
+   * The threshold, measured in degrees, that determines when
+   * the map's bearing (rotation) will snap to north. For
+   * example, with a  bearingSnap of 7, if the user rotates the
+   * map within 7 degrees of north, the map will automatically
+   * snap to exact north.
+   */
+  bearingSnap?: number;
+
+  /**
+   * If `false`, the map's pitch (tilt) control with "drag to
+   * rotate" interaction will be disabled.
+   */
+  pitchWithRotate?: boolean;
+
+  /** If `true`, an AttributionControl will be added to the map. */
+  attributionControl?: boolean;
+
+  /* A string representing the position of the Mapbox wordmark on the map. */
+  logoPosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+  /**
+   * If `true`, map creation will fail if the performance of Mapbox
+   * GL JS would be dramatically worse than expected (i.e. a software
+   * renderer would be used).
+   */
+  failIfMajorPerformanceCaveat?: boolean;
+
+  /**
+   * Mapbox WebGL context creation option.
+   * Useful when you want to export the canvas as a PNG.
+   */
+  preserveDrawingBuffer?: boolean;
+
+  /**
+   * If `true`, the gl context will be created with MSAA antialiasing,
+   * which can be useful for antialiasing custom layers. this is `false`
+   * by default as a performance optimization.
+   */
+  antialias?: boolean;
+
+  /**
+   * If `false`, the map won't attempt to re-request tiles once they
+   * expire per their HTTP `cacheControl`/`expires` headers.
+   */
+  refreshExpiredTiles?: boolean;
+
+  /** If set, the map will be constrained to the given bounds. */
+  maxBounds?: LngLatBoundsLike;
+
+  /**
+   * The initial bounds of the map. If bounds is specified,
+   * it overrides center and zoom constructor options.
+   * */
+  bounds?: LngLatBoundsLike;
+
+  /** If `true`, the "scroll to zoom" interaction is enabled. */
+  scrollZoom?: boolean | Object;
+
+  /** If `true`, the "box zoom" interaction is enabled */
+  boxZoom?: boolean;
+
+  /** If `true`, the "drag to rotate" interaction is enabled */
+  dragRotate?: boolean;
+
+  /** If `true`, the "drag to pan" interaction is enabled */
+  dragPan?: boolean;
+
+  /** If `true`, keyboard shortcuts are enabled */
+  keyboard?: boolean;
+
+  /** If `true`, the "double click to zoom" interaction is enabled */
+  doubleClickZoom?: boolean;
+
+  /**
+   * If `true`, the map will automatically resize
+   * when the browser window resizes.
+   */
+  trackResize?: boolean;
+
+  /**
+   * The maximum number of tiles stored in the tile cache for a given
+   * source. If omitted, the cache will be dynamically sized based on
+   * the current viewport.
+   */
+  maxTileCacheSize?: number;
+
+  /**
+   * If `true`, multiple copies of the world
+   * will be rendered, when zoomed out
+   */
+  renderWorldCopies?: boolean;
+
+  /**
+   * If specified, defines a CSS font-family for locally overriding
+   * generation of glyphs in the 'CJK Unified Ideographs' and
+   * 'Hangul Syllables' ranges. In these ranges, font settings from the
+   * map's style will be ignored, except for font-weight keywords
+   * (light/regular/medium/bold). The purpose of this option is to avoid
+   * bandwidth-intensive glyph server requests.
+   * (see https://www.mapbox.com/mapbox-gl-js/example/local-ideographs )
+   */
+  localIdeographFontFamily?: boolean;
+
+  /**
+   * A callback run before the Map makes a request for an external URL.
+   * The callback can be used to modify the url, set headers, or set the
+   * credentials property for cross-origin requests. Expected to return
+   * an object with a  url property and optionally  headers and
+   * credentials properties.
+   */
+  transformRequest?: (
+    url: string,
+    resourceType: string
+  ) => { url: string; headers?: Object; credentials?: string };
+
+  /**
+   * If true, Resource Timing API information will be collected for
+   * requests made by GeoJSON and Vector Tile web workers (this information
+   * is normally inaccessible from the main Javascript thread). Information
+   * will be returned in a resourceTiming property of relevant data events.
+   */
+  collectResourceTiming?: boolean;
+
+  /**
+   * Controls the duration of the fade-in/fade-out animation for label
+   * collisions, in milliseconds. This setting affects all symbol layers.
+   * This setting does not affect the duration of runtime styling transitions
+   * or raster tile cross-fading.
+   */
+  fadeDuration?: number;
+
+  /**
+   * If `true`, symbols from multiple sources can collide with each
+   * other during collision detection. If `false`, collision detection
+   * is run separately for the symbols in each source.
+   */
+  crossSourceCollisions?: boolean;
+
+  /**
+   * A patch to apply to the default localization table for UI strings,
+   * e.g. control tooltips. The `locale` object maps namespaced UI string IDs
+   * to translated strings in the target language;
+   * see `src/ui/default_locale.js` for an example with all supported
+   * string IDs. The object may specify all UI strings (thereby adding support
+   * for a new translation) or only a subset of strings (thereby patching
+   * the default translation table).
+   */
+  locale?: string;
+
+  /**
+   * `onViewportChange` callback is fired when the user interacted with the
+   * map. The object passed to the callback contains viewport properties
+   * such as `longitude`, `latitude`, `zoom` etc.
+   */
+  onViewportChange?: (viewport: Viewport) => void;
+
+  /**
+   * Map method that will be called after new viewport props are received.
+   */
+  viewportChangeMethod?: ViewportChangeMethod;
+
+  /**
+   * Options common to map movement methods that involve animation,
+   * controlling the duration and easing function of the animation.
+   * This options will be passed to the `viewportChangeMethod` call.
+   * (see https://docs.mapbox.com/mapbox-gl-js/api/#animationoptions)
+   */
+  viewportChangeOptions?: AnimationOptions;
+
+  /** The onLoad callback for the map */
+  onLoad?: Function;
+
+  /** Map cursor style as CSS value */
+  cursorStyle?: string;
+
+  /**
+   * Sets a Boolean indicating whether the map will render an outline around
+   * each tile and the tile ID. These tile boundaries are useful for debugging.
+   * */
+  showTileBoundaries?: boolean;
+};
+
+type State = {
+  loaded: boolean;
+};
+
+export default class MapGL extends PureComponent<Props, State> {
+  constructor(props: Props);
+
+  state: State;
+
+  getMap(): Map;
+}

--- a/src/components/Marker/index.d.ts
+++ b/src/components/Marker/index.d.ts
@@ -1,0 +1,80 @@
+import { PureComponent, ReactNode } from "react";
+import type { Marker as MapboxMarker, PointLike, LngLat } from "mapbox-gl";
+
+type Props = {
+  /** Marker content */
+  children: ReactNode;
+
+  /**
+   * A string indicating the part of the Marker
+   * that should be positioned closest to the coordinate
+   */
+  anchor:
+    | "center"
+    | "top"
+    | "bottom"
+    | "left"
+    | "right"
+    | "top-left"
+    | "top-right"
+    | "bottom-left"
+    | "bottom-right";
+
+  /** The longitude of the center of the marker. */
+  longitude: number;
+
+  /** The latitude of the center of the marker. */
+  latitude: number;
+
+  /**
+   * The offset in pixels as a `PointLike` object to apply
+   * relative to the element's center. Negatives indicate left and up.
+   */
+  offset?: PointLike;
+
+  /**
+   * Boolean indicating whether or not a marker is able to be dragged
+   * to a new position on the map.
+   */
+  draggable?: boolean;
+
+  /**
+   * The rotation angle of the marker in degrees, relative to its
+   * respective `rotationAlignment` setting. A positive value will
+   * rotate the marker clockwise.
+   */
+  rotation: number;
+
+  /**
+   * map aligns the `Marker` to the plane of the map. `viewport`
+   * aligns the  Marker to the plane of the viewport. `auto` automatically
+   * matches the value of `rotationAlignment`.
+   */
+  pitchAlignment: string;
+
+  /**
+   * map aligns the `Marker`'s rotation relative to the map, maintaining
+   * a bearing as the map rotates. `viewport` aligns the `Marker`'s rotation
+   * relative to the viewport, agnostic to map rotations.
+   * `auto` is equivalent to `viewport`.
+   */
+  rotationAlignment: string;
+
+  /** Fired when the marker is clicked */
+  onClick?: () => any;
+
+  /** Fired when the marker is finished being dragged */
+  onDragEnd?: (lngLat: LngLat) => any;
+
+  /** Fired when the marker is finished being dragged */
+  onDragStart?: (lngLat: LngLat) => any;
+
+  /** Fired when the marker is dragged */
+  onDrag?: (lngLat: LngLat) => any;
+};
+
+export default class Marker extends PureComponent<Props> {
+  constructor(props: Props);
+
+  getMarker(): MapboxMarker;
+}

--- a/src/components/NavigationControl/index.d.ts
+++ b/src/components/NavigationControl/index.d.ts
@@ -1,0 +1,23 @@
+import { PureComponent } from "react";
+import type { NavigationControl as MapboxNavigationControl } from "mapbox-gl";
+
+type Props = {
+  /** If true the compass button is included. */
+  showCompass: boolean;
+
+  /** If true the zoom-in and zoom-out buttons are included. */
+  showZoom: boolean;
+
+  /**
+   * If true the pitch is visualized by rotating X-axis of compass
+   * and pitch will reset by clicking on the compass.
+   */
+  visualizePitch: boolean;
+
+  /** A string representing the position of the control on the map. */
+  position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+};
+
+export default class NavigationControl extends PureComponent<Props> {
+  getControl(): MapboxNavigationControl;
+}

--- a/src/components/Popup/index.d.ts
+++ b/src/components/Popup/index.d.ts
@@ -1,0 +1,57 @@
+import { PureComponent, ReactNode } from "react";
+import type { Popup as MapboxPopup, LngLatBoundsLike } from "mapbox-gl";
+
+type Props = {
+  /** Popup content. */
+  children: ReactNode;
+
+  /** The longitude of the center of the popup. */
+  longitude: number;
+
+  /** The latitude of the center of the popup. */
+  latitude: number;
+
+  /*
+   * If true, a close button will appear
+   * in the top right corner of the popup.
+   */
+  closeButton?: boolean;
+
+  /** If true, the popup will closed when the map is clicked. */
+  closeOnClick?: boolean;
+
+  /** The onClose callback is fired when the popup closed. */
+  onClose?: Function;
+
+  /*
+   * A string indicating the part of the Popup
+   * that should be positioned closest to the coordinate.
+   * */
+  anchor?:
+    | "top"
+    | "bottom"
+    | "left"
+    | "right"
+    | "top-left"
+    | "top-right"
+    | "bottom-left"
+    | "bottom-right";
+
+  /**
+   * The offset in pixels as a `PointLike` object to apply
+   * relative to the element's center. Negatives indicate left and up.
+   */
+  offset?: LngLatBoundsLike;
+
+  /** The className of the popup */
+  className?: string;
+
+  /** A string that sets the CSS property of the popup's maximum width. */
+  maxWidth?: string;
+};
+
+export default class Popup extends PureComponent<Props> {
+  constructor(props: Props);
+
+  getPopup(): MapboxPopup;
+}

--- a/src/components/ScaleControl/index.d.ts
+++ b/src/components/ScaleControl/index.d.ts
@@ -1,0 +1,17 @@
+import { PureComponent } from "react";
+import type { ScaleControl as MapboxScaleControl } from "mapbox-gl";
+
+type Props = {
+  /* The maximum length of the scale control in pixels. */
+  maxWidth: number;
+
+  /* Unit of the distance. */
+  unit: "imperial" | "metric" | "nautical";
+
+  /* A string representing the position of the control on the map. */
+  position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+};
+
+export default class ScaleControl extends PureComponent<Props> {
+  getControl(): MapboxScaleControl;
+}

--- a/src/components/Source/index.d.ts
+++ b/src/components/Source/index.d.ts
@@ -1,0 +1,25 @@
+import type {
+  SourceSpecification,
+  RasterSourceSpecification,
+  VectorSourceSpecification,
+} from "mapbox-gl/src/style-spec/types";
+import { PureComponent, ReactNode } from "react";
+import { ProgressPlugin } from "webpack";
+
+export type TileSourceSpecification =
+  | VectorSourceSpecification
+  | RasterSourceSpecification;
+
+export type Props = SourceSpecification & {
+  /** Mapbox GL Source id */
+  id: string;
+
+  /** Layers */
+  children?: ReactNode;
+};
+
+type State = {
+  loaded: boolean;
+};
+
+export default class Source extends PureComponent<ProgressPlugin, State> {}

--- a/src/components/Source/index.d.ts
+++ b/src/components/Source/index.d.ts
@@ -4,7 +4,6 @@ import type {
   VectorSourceSpecification,
 } from "mapbox-gl/src/style-spec/types";
 import { PureComponent, ReactNode } from "react";
-import { ProgressPlugin } from "webpack";
 
 export type TileSourceSpecification =
   | VectorSourceSpecification
@@ -22,4 +21,4 @@ type State = {
   loaded: boolean;
 };
 
-export default class Source extends PureComponent<ProgressPlugin, State> {}
+export default class Source extends PureComponent<Props, State> {}

--- a/src/components/TrafficControl/index.d.ts
+++ b/src/components/TrafficControl/index.d.ts
@@ -1,0 +1,20 @@
+import { PureComponent } from "react";
+import type MapboxTrafficControl from "@mapbox/mapbox-gl-traffic";
+
+type Props = {
+  /** Show or hide traffic overlay by default. */
+  showTraffic?: Boolean;
+
+  /** Show a toggle button to turn traffic on and off. */
+  showTrafficButton?: Boolean;
+
+  /**
+   * The traffic source regex used to determine whether a layer displays
+   * traffic or not
+   * */
+  trafficSource?: RegExp;
+};
+
+export default class TrafficControl extends PureComponent<Props> {
+  getControl(): MapboxTrafficControl;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,18 @@
+export { default } from "./components/MapGL";
+
+export { default as MapContext } from "./components/MapContext";
+export { default as Layer } from "./components/Layer";
+export { default as CustomLayer } from "./components/CustomLayer";
+export { default as Source } from "./components/Source";
+export { default as Popup } from "./components/Popup";
+export { default as Marker } from "./components/Marker";
+export { default as FeatureState } from "./components/FeatureState";
+export { default as Image } from "./components/Image";
+export { default as AttributionControl } from "./components/AttributionControl";
+export { default as FullscreenControl } from "./components/FullscreenControl";
+export { default as GeolocateControl } from "./components/GeolocateControl";
+export { default as NavigationControl } from "./components/NavigationControl";
+export { default as ScaleControl } from "./components/ScaleControl";
+export { default as LanguageControl } from "./components/LanguageControl";
+export { default as TrafficControl } from "./components/TrafficControl";
+export { default as Filter } from "./components/Filter";


### PR DESCRIPTION
This addresses #290 and adds type definitions for all components.

Ideally these types would live in this repository so that they can be updated as the library itself is updated, but I can move this to DefinitelyTyped if preferred.