### PR TITLE
Add TypeScript definition files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "main": "dist/react-map-gl.cjs.js",
   "module": "dist/react-map-gl.esm.js",
   "files": [
+    "**/*.d.ts",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
Without this, the newly added typescript definitions will be stripped out on publish