### PR TITLE
fix: use `undefined` as default Popup props

### DIFF
--- a/src/components/Popup/index.js
+++ b/src/components/Popup/index.js
@@ -70,10 +70,10 @@ class Popup extends PureComponent<Props> {
   static defaultProps = {
     closeButton: true,
     closeOnClick: true,
-    onClose: null,
-    anchor: null,
-    offset: null,
-    className: null,
+    onClose: undefined,
+    anchor: undefined,
+    offset: undefined,
+    className: undefined,
     maxWidth: '240px'
   };
 


### PR DESCRIPTION
Relates to #403 https://github.com/mapbox/mapbox-gl-js/issues/11955