### PR TITLE
Add Fog component

### DIFF
--- a/src/components/Fog/README.md
+++ b/src/components/Fog/README.md
@@ -1,0 +1,31 @@
+A `Fog` component sets the fog property of the style.
+
+```jsx
+import React, { useState } from 'react';
+import MapGL, { Fog } from '@urbica/react-map-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+const [viewport, setViewport] = useState({
+  latitude: 37.830348,
+  longitude: -100.486052,
+  pitch: 90,
+  zoom: 2
+});
+
+<MapGL
+  style={{ width: '100%', height: '400px' }}
+  mapStyle='mapbox://styles/mapbox/light-v9'
+  accessToken={MAPBOX_ACCESS_TOKEN}
+  onViewportChange={setViewport}
+  {...viewport}
+>
+  <Fog
+    range={[0.8, 8]}
+    color={'#dc9f9f'}
+    horizon-blend={0.5}
+    high-color={'#245bde'}
+    space-color={'#000000'}
+    star-intensity={0.15}
+  />
+</MapGL>;
+```

--- a/src/components/Fog/index.d.ts
+++ b/src/components/Fog/index.d.ts
@@ -1,0 +1,45 @@
+import { PureComponent } from "react";
+import type { FogSpecification, Expression } from "mapbox-gl";
+
+type Props = {
+  /** The color of the atmosphere region immediately below 
+   * the horizon and within the range and above the horizon 
+   * and within horizon-blend. */
+  color?: String | Expression,
+
+  /** The color of the atmosphere region above the horizon, 
+   * high-color extends further above the horizon than the 
+   * color property and its spread can be controlled with 
+   * horizon-blend. */
+  'high-color'?: String | Expression,
+
+  /**
+   * Horizon blend applies a smooth fade from the color of
+   * the atmosphere to the color of space.
+   */
+  'horizon-blend'?: Number | Expression,
+
+  /**
+   * The start and end distance range in which fog fades from 
+   * fully transparent to fully opaque.
+   */
+  range?: [Number, Number],
+
+  /**
+   * The color of the region above the horizon and after the 
+   * end of the horizon-blend contribution.
+   */
+  'space-color'?: String | Expression;
+
+  /**
+   * A value controlling the star intensity where 0 will show 
+   * no stars and 1 will show stars at their maximum intensity.
+   */
+  'star-intensity'?: Number | Expression;
+};
+
+export default class Fog extends PureComponent<Props> {
+  constructor(props: Props);
+
+  getFog(): FogSpecification;
+}

--- a/src/components/Fog/index.js
+++ b/src/components/Fog/index.js
@@ -1,0 +1,101 @@
+// @flow
+
+import { PureComponent, createElement } from 'react';
+import type MapboxMap from 'mapbox-gl/src/ui/map';
+import type { Expression } from 'mapbox-gl';
+
+import MapContext from '../MapContext';
+
+type Props = {
+  /** The color of the atmosphere region immediately below 
+   * the horizon and within the range and above the horizon 
+   * and within horizon-blend. */
+  color?: String | Expression,
+
+  /** The color of the atmosphere region above the horizon, 
+   * high-color extends further above the horizon than the 
+   * color property and its spread can be controlled with 
+   * horizon-blend. */
+  'high-color'?: String | Expression,
+
+  /**
+   * Horizon blend applies a smooth fade from the color of
+   * the atmosphere to the color of space.
+   */
+  'horizon-blend'?: Number | Expression,
+
+  /**
+   * The start and end distance range in which fog fades from 
+   * fully transparent to fully opaque.
+   */
+  range?: [Number, Number],
+
+  /**
+   * The color of the region above the horizon and after the 
+   * end of the horizon-blend contribution.
+   */
+  'space-color'?: String | Expression;
+
+  /**
+   * A value controlling the star intensity where 0 will show 
+   * no stars and 1 will show stars at their maximum intensity.
+   */
+  'star-intensity'?: Number | Expression;
+};
+
+class Fog extends PureComponent<Props> {
+  _map: MapboxMap;
+
+  static displayName = 'Fog';
+
+  static defaultProps = {
+    color: '#ffffff',
+    'high-color': '#245cdf',
+    'horizon-blend': ["interpolate", ["linear"], ["zoom"], 4, 0.2, 7, 0.1],
+    range: [0.5, 10],
+    'space-color': ["interpolate", ["linear"], ["zoom"], 4, "#010b19", 7, "#367ab9"],
+    'star-intensity': ["interpolate", ["linear"], ["zoom"], 5, 0.35, 6, 0],
+  };
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    /**
+     * Fog since version 2.3.0, not support below versions.
+     */
+    if (!this._map.setFog) return;
+    this._map.setFog(this.props);
+  }
+
+  componentDidUpdate() {
+    if (!this._map.setFog) return;
+    this._map.setFog(this.props);
+  }
+
+  componentWillUnmount() {
+    if (!this._map || !this._map.getStyle() || !this._map.setFog) {
+      return;
+    }
+
+    this._map.setFog();
+  }
+
+  getFog() {
+    if (!this._map.getFog) return;
+    return this._map.getFog();
+  }
+
+  render() {
+    return createElement(MapContext.Consumer, {}, (map) => {
+      if (map) {
+        this._map = map;
+      }
+
+      return null;
+    });
+  }
+}
+
+export default Fog;

--- a/src/components/Fog/index.test.js
+++ b/src/components/Fog/index.test.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import MapGL, { Source, Fog } from '../..';
+
+test('render', () => {
+  const wrapper = mount(
+    <MapGL latitude={0} longitude={0} zoom={0}>
+      <Fog range={[0.5, 10]} color={'#ff0000'} />
+    </MapGL>
+  );
+
+  expect(wrapper.find('Fog').exists()).toBe(true);
+
+  wrapper.unmount();
+  expect(wrapper.find('Fog').exists()).toBe(false);
+});
+
+test('update', () => {
+  const wrapper = mount(
+    <MapGL latitude={0} longitude={0} zoom={0}>
+      <Fog range={[0.5, 10]} color={'#ff0000'} />
+    </MapGL>
+  );
+
+  wrapper.setProps({
+    children: [
+      <Fog range={[0.5, 5]} color={'#ffff00'} />
+    ]
+  });
+});
+
+test('throws', () => {
+  console.error = jest.fn();
+
+  expect(() =>
+    mount(<Fog range={[0.5, 5]} color={'#ffff00'} />)
+  ).toThrow();
+
+  expect(console.error).toHaveBeenCalled();
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,3 +16,4 @@ export { default as ScaleControl } from "./components/ScaleControl";
 export { default as LanguageControl } from "./components/LanguageControl";
 export { default as TrafficControl } from "./components/TrafficControl";
 export { default as Filter } from "./components/Filter";
+export { default as Fog } from './components/Fog';

--- a/src/index.js
+++ b/src/index.js
@@ -20,3 +20,4 @@ export { default as ScaleControl } from './components/ScaleControl';
 export { default as LanguageControl } from './components/LanguageControl';
 export { default as TrafficControl } from './components/TrafficControl';
 export { default as Filter } from './components/Filter';
+export { default as Fog } from './components/Fog';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -32,7 +32,8 @@ module.exports = {
         'src/components/Popup/index.js',
         'src/components/Marker/index.js',
         'src/components/FeatureState/index.js',
-        'src/components/Filter/index.js'
+        'src/components/Filter/index.js',
+        'src/components/Fog/index.js'
       ]
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,9 +1141,9 @@
     earcut "^2.0.6"
 
 "@deck.gl/mapbox@^8.8.3":
-  version "8.8.9"
-  resolved "https://registry.yarnpkg.com/@deck.gl/mapbox/-/mapbox-8.8.9.tgz#e7814e666df260be7d5fcb90f4ae092e1a7c4d48"
-  integrity sha512-3CmQjon797QLU1FbVktJyUIFjH9Dipc1KnJG9yBVQBXw7fCALqhYbtZ0oTJqTSfYVE6pnc7BQFcZYPTpHlHuJg==
+  version "8.8.10"
+  resolved "https://registry.yarnpkg.com/@deck.gl/mapbox/-/mapbox-8.8.10.tgz#7fafe378dd0b405946df5b43a103665dc82bc41f"
+  integrity sha512-NwR92nVsnfEtdUkR6kVY0wac3L4VAjrsfRetE/cEJ6A/McJwELhhBbUckxv3oO4v0p9UVuIB2AM71g1m9loTxg==
   dependencies:
     "@types/mapbox-gl" "^2.6.3"
 


### PR DESCRIPTION
mapbox-gl has `setFog` method since version 2.3.0, I think we can add a `Fog` component like `FeatureState` component.
Hope you can accept it!